### PR TITLE
Correction to the GraphViz function when drawing empty nodes

### DIFF
--- a/merkletree.go
+++ b/merkletree.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"strings"
 	"sync"
 
 	"github.com/iden3/go-iden3-core/common"
@@ -603,11 +604,15 @@ node [fontname=Monospace,fontsize=10,shape=box]
 			for i := range lr {
 				if lr[i] == "0" {
 					lr[i] = fmt.Sprintf("empty%v", cnt)
-					fmt.Fprintf(w, "\"%v\" [style=dashed,label=0];\n", lr[i])
 					cnt++
 				}
 			}
 			fmt.Fprintf(w, "\"%v\" -> {\"%v\" \"%v\"}\n", k.BigInt().String(), lr[0], lr[1])
+			for i := range lr {
+				if strings.HasPrefix(lr[i], "empty") {
+					fmt.Fprintf(w, "\"%v\" [style=dashed,label=0];\n", lr[i])
+				}
+			}
 		default:
 		}
 	})

--- a/merkletree.go
+++ b/merkletree.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"strings"
 	"sync"
 
 	"github.com/iden3/go-iden3-core/common"
@@ -56,11 +55,18 @@ var (
 // Hash is the generic type stored in the MerkleTree
 type Hash [32]byte
 
+// String returns decimal representation in string format of the Hash
 func (h Hash) String() string {
-	return new(big.Int).SetBytes(h[:]).String()
+	s := h.BigInt().String()
+	if len(s) < 8 {
+		return s
+	}
+	return s[0:8] + "..."
 }
+
+// Hex returns the hexadecimal representation of the Hash
 func (h Hash) Hex() string {
-	return hex.EncodeToString(h[:])
+	return hex.EncodeToString(h.BigInt().Bytes())
 }
 
 // BigInt returns the *big.Int representation of the *Hash
@@ -598,21 +604,19 @@ node [fontname=Monospace,fontsize=10,shape=box]
 		switch n.Type {
 		case NodeTypeEmpty:
 		case NodeTypeLeaf:
-			fmt.Fprintf(w, "\"%v\" [style=filled];\n", k.BigInt().String())
+			fmt.Fprintf(w, "\"%v\" [style=filled];\n", k.String())
 		case NodeTypeMiddle:
-			lr := [2]string{n.ChildL.BigInt().String(), n.ChildR.BigInt().String()}
+			lr := [2]string{n.ChildL.String(), n.ChildR.String()}
+			emptyNodes := ""
 			for i := range lr {
 				if lr[i] == "0" {
 					lr[i] = fmt.Sprintf("empty%v", cnt)
+					emptyNodes += fmt.Sprintf("\"%v\" [style=dashed,label=0];\n", lr[i])
 					cnt++
 				}
 			}
-			fmt.Fprintf(w, "\"%v\" -> {\"%v\" \"%v\"}\n", k.BigInt().String(), lr[0], lr[1])
-			for i := range lr {
-				if strings.HasPrefix(lr[i], "empty") {
-					fmt.Fprintf(w, "\"%v\" [style=dashed,label=0];\n", lr[i])
-				}
-			}
+			fmt.Fprintf(w, "\"%v\" -> {\"%v\" \"%v\"}\n", k.String(), lr[0], lr[1])
+			fmt.Fprint(w, emptyNodes)
 		default:
 		}
 	})


### PR DESCRIPTION
GraphViz function always draws empty nodes on the left. It is because the empty node was declared before being used.